### PR TITLE
Feat/premise vulgarity check

### DIFF
--- a/api/controllers/checkpremise.php
+++ b/api/controllers/checkpremise.php
@@ -4,10 +4,10 @@
  *
  * Expects the POST parameter `premise` to be set.
  * This script assumes $output is initialized in the calling script (e.g., index.php)
- * and that GOOGLE_KEY is available/defined globally, typically via `includes/key.php`
+ * and that PERSPECTIVE_KEY is available/defined globally, typically via `includes/key.php`
  * being included in the main `index.php`.
  *
- * The script will set $output->error and $output->vulgarity.
+ * The script will set $output->error and $output->json.
  *
  * @example
     // Success Response JSON
@@ -29,12 +29,12 @@
 
 // Define a placeholder for the Google API key if not already defined.
 // This is mainly for isolated testing IF key.php was not included by index.php
-// OR if GOOGLE_KEY was not in key.php.
-// In a standard operational flow, GOOGLE_KEY should be defined by index.php including key.php.
-if (!defined('GOOGLE_KEY')) {
+// OR if PERSPECTIVE_KEY was not in key.php.
+// In a standard operational flow, PERSPECTIVE_KEY should be defined by index.php including key.php.
+if (!defined('PERSPECTIVE_KEY')) {
     // This fallback makes the controller runnable in isolation for basic tests,
-    // but it's not the primary way GOOGLE_KEY should be provided.
-    define('GOOGLE_KEY', 'TEST_GOOGLE_KEY_ISOLATED');
+    // but it's not the primary way PERSPECTIVE_KEY should be provided.
+    define('PERSPECTIVE_KEY', 'TEST_PERSPECTIVE_KEY_ISOLATED');
 }
 
 define('OBSCENE_THRESHOLD', 0.5); // Threshold for 'OBSCENE' attribute
@@ -43,7 +43,7 @@ define('OBSCENE_THRESHOLD', 0.5); // Threshold for 'OBSCENE' attribute
  * Calls the Perspective API to analyze text.
  *
  * @param string $text The text to analyze.
- * @param string $apiKey The API key for the Perspective API (should be GOOGLE_KEY).
+ * @param string $apiKey The API key for the Perspective API (should be PERSPECTIVE_KEY).
  * @return object|false The decoded JSON response from the API, or false on error.
  */
 function callPerspectiveAPI($text, $apiKey) {
@@ -90,66 +90,66 @@ $premise = isset($_POST['premise']) ? $_POST['premise'] : '';
 
 if (empty($premise)) {
     $output->error = "Premise input is empty.";
-    $output->vulgarity = null;
+    $output->json = null;
 }
-// Check if GOOGLE_KEY is defined and not empty.
-// The fallback 'TEST_GOOGLE_KEY_ISOLATED' is allowed to proceed for isolated testing.
-else if (!defined('GOOGLE_KEY') || GOOGLE_KEY === '') {
-    // This case implies GOOGLE_KEY was explicitly defined as empty, or was not defined at all AND
-    // the fallback define('GOOGLE_KEY', 'TEST_GOOGLE_KEY_ISOLATED') was somehow skipped or GOOGLE_KEY became undefined again.
+// Check if PERSPECTIVE_KEY is defined and not empty.
+// The fallback 'TEST_PERSPECTIVE_KEY_ISOLATED' is allowed to proceed for isolated testing.
+else if (!defined('PERSPECTIVE_KEY') || PERSPECTIVE_KEY === '') {
+    // This case implies PERSPECTIVE_KEY was explicitly defined as empty, or was not defined at all AND
+    // the fallback define('PERSPECTIVE_KEY', 'TEST_PERSPECTIVE_KEY_ISOLATED') was somehow skipped or PERSPECTIVE_KEY became undefined again.
     // Primarily, this catches an empty string from key.php.
-    $output->error = "Google API key (GOOGLE_KEY) for Perspective API is not configured (empty or not defined). Please check main configuration (includes/key.php).";
-    $output->vulgarity = null;
+    $output->error = "Google API key (PERSPECTIVE_KEY) for Perspective API is not configured (empty or not defined). Please check main configuration (includes/key.php).";
+    $output->json = null;
 }
 // If key is the specific test key (either from this script's fallback or a test setup),
 // it's for testing the call path, but it's not a *valid* production key.
 // The API call will proceed and likely fail at the API endpoint, which is expected.
-else if (GOOGLE_KEY === 'TEST_GOOGLE_KEY_ISOLATED' || GOOGLE_KEY === 'TEST_GOOGLE_KEY') { // Second condition for tests
-    $apiResponse = callPerspectiveAPI($premise, GOOGLE_KEY);
+else if (PERSPECTIVE_KEY === 'TEST_PERSPECTIVE_KEY_ISOLATED' || PERSPECTIVE_KEY === 'TEST_PERSPECTIVE_KEY') { // Second condition for tests
+    $apiResponse = callPerspectiveAPI($premise, PERSPECTIVE_KEY);
 
     if ($apiResponse === false) {
-        $output->error = "Error calling moderation API (using a test key: " . GOOGLE_KEY . ").";
-        $output->vulgarity = null;
+        $output->error = "Error calling moderation API (using a test key: " . PERSPECTIVE_KEY . ").";
+        $output->json = null;
     } elseif (isset($apiResponse->attributeScores->OBSCENE->summaryScore->value)) {
         $output->error = ""; // Clear error
         $obsceneScore = $apiResponse->attributeScores->OBSCENE->summaryScore->value;
 
-        $output->vulgarity = new stdClass();
-        $output->vulgarity->score = $obsceneScore;
-        $output->vulgarity->reject = ($obsceneScore > OBSCENE_THRESHOLD);
+        $output->json = new stdClass();
+        $output->json->score = $obsceneScore;
+        $output->json->reject = ($obsceneScore > OBSCENE_THRESHOLD);
     } else {
-        $output->error = "Invalid response from moderation API (using a test key: " . GOOGLE_KEY . ").";
+        $output->error = "Invalid response from moderation API (using a test key: " . PERSPECTIVE_KEY . ").";
         if (isset($apiResponse->error->message)) {
              $output->error .= " - API Message: " . $apiResponse->error->message;
         }
-        $output->vulgarity = null;
+        $output->json = null;
     }
 }
-// This is the normal operational path if GOOGLE_KEY is defined, not empty, and not a test key.
+// This is the normal operational path if PERSPECTIVE_KEY is defined, not empty, and not a test key.
 else {
-    $apiResponse = callPerspectiveAPI($premise, GOOGLE_KEY);
+    $apiResponse = callPerspectiveAPI($premise, PERSPECTIVE_KEY);
 
     if ($apiResponse === false) {
         $output->error = "Error calling moderation API.";
-        $output->vulgarity = null;
+        $output->json = null;
     } elseif (isset($apiResponse->attributeScores->OBSCENE->summaryScore->value)) {
         $output->error = ""; // Clear error if API call was successful and response is valid
         $obsceneScore = $apiResponse->attributeScores->OBSCENE->summaryScore->value;
 
-        $output->vulgarity = new stdClass();
-        $output->vulgarity->score = $obsceneScore;
-        $output->vulgarity->reject = ($obsceneScore > OBSCENE_THRESHOLD);
+        $output->json = new stdClass();
+        $output->json->score = $obsceneScore;
+        $output->json->reject = ($obsceneScore > OBSCENE_THRESHOLD);
     } else {
         $output->error = "Invalid response from moderation API.";
          if (isset($apiResponse->error->message)) {
              $output->error .= " - API Message: " . $apiResponse->error->message;
          }
-        $output->vulgarity = null;
+        $output->json = null;
     }
 }
 
 // The calling script (index.php) is responsible for:
-// - Ensuring GOOGLE_KEY is defined (typically by including includes/key.php)
+// - Ensuring PERSPECTIVE_KEY is defined (typically by including includes/key.php)
 // - Initializing $output object
 // - Setting header('Content-Type: application/json');
 // - echo json_encode($output);

--- a/api/controllers/checkpremise.php
+++ b/api/controllers/checkpremise.php
@@ -99,10 +99,14 @@ else {
     } elseif (isset($apiResponse->attributeScores->OBSCENE->summaryScore->value)) {
         $output->error = ""; // Clear error if API call was successful and response is valid
         $obsceneScore = $apiResponse->attributeScores->OBSCENE->summaryScore->value;
+        $toxicityScore = $apiResponse->attributeScores->TOXICITY->summaryScore->value;
+        $severeToxicityScore = $apiResponse->attributeScores->SEVERE_TOXICITY->summaryScore->value;
 
         $output->json = new stdClass();
         $output->json->score = $obsceneScore;
-        $output->json->reject = ($obsceneScore > OBSCENE_THRESHOLD);
+        $output->json->toxicity = $toxicityScore;
+        $output->json->severeToxicity = $severeToxicityScore;
+        $output->json->reject = ($obsceneScore > OBSCENE_THRESHOLD || $toxicityScore > OBSCENE_THRESHOLD || $severeToxicityScore > OBSCENE_THRESHOLD);
     } else {
         $output->error = "Invalid response from moderation API.";
          if (isset($apiResponse->error->message)) {

--- a/api/controllers/checkpremise.php
+++ b/api/controllers/checkpremise.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Checks the premise for vulgarity using the Perspective API.
+ *
+ * Expects the POST parameter `premise` to be set.
+ *
+ * @example
+    // Response JSON
+    {
+        "error": "",
+        "json": {
+            "vulgarity": false
+        },
+        "model": "perspective_api"
+    }
+ */
+
+// Try to include the key file, otherwise define a dummy key for testing
+if (file_exists(__DIR__ . '/../includes/key.php')) {
+    include_once __DIR__ . '/../includes/key.php';
+}
+
+// Define a placeholder for the Perspective API key if not already defined
+if (!defined('PERSPECTIVE_API_KEY')) {
+    define('PERSPECTIVE_API_KEY', 'TEST_API_KEY'); // Dummy key for subtask execution
+}
+
+define('OBSCENE_THRESHOLD', 0.5);
+
+/**
+ * Calls the Perspective API to analyze text.
+ *
+ * @param string $text The text to analyze.
+ * @param string $apiKey The API key for the Perspective API.
+ * @return object|false The decoded JSON response from the API, or false on error.
+ */
+function callPerspectiveAPI($text, $apiKey) {
+    $url = "https://commentanalyzer.googleapis.com/v1alpha1/comments:analyze?key=" . $apiKey;
+
+    $data = [
+        "comment" => ["text" => $text],
+        // "languages" => ["en"], // Omitted for auto-detection as per requirement
+        "requestedAttributes" => [
+            "OBSCENE" => new stdClass(), // Using stdClass for empty JSON object {}
+            "TOXICITY" => new stdClass(),
+            "SEVERE_TOXICITY" => new stdClass()
+        ]
+    ];
+    $jsonData = json_encode($data);
+
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $jsonData);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+
+    $response = curl_exec($ch);
+
+    if (curl_errno($ch)) {
+        // Optionally log curl_error($ch)
+        curl_close($ch);
+        return false;
+    }
+
+    curl_close($ch);
+
+    $decodedResponse = json_decode($response);
+
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        // Optionally log json_last_error_msg() and the raw $response
+        return false;
+    }
+
+    return $decodedResponse;
+}
+
+// Initialize the output object
+$output = new stdClass();
+$output->json = new stdClass();
+$output->model = "perspective_api"; // Set model early
+
+// Get the premise from the POST request
+$premise = isset($_POST['premise']) ? $_POST['premise'] : '';
+
+if (empty($premise)) {
+    $output->error = "Premise input is empty.";
+    $output->json->vulgarity = null;
+} elseif (!defined('PERSPECTIVE_API_KEY') || PERSPECTIVE_API_KEY === 'YOUR_PERSPECTIVE_API_KEY_HERE' || PERSPECTIVE_API_KEY === 'TEST_API_KEY' || PERSPECTIVE_API_KEY === '') {
+    // Added check for the default placeholder value or an empty string
+    // In a real scenario, 'TEST_API_KEY' would also be an invalid key for actual API calls.
+    // For this subtask, we proceed if it's TEST_API_KEY to allow testing the call structure.
+    // However, if it's the initial placeholder or empty, it's an error.
+    if (PERSPECTIVE_API_KEY === 'YOUR_PERSPECTIVE_API_KEY_HERE' || PERSPECTIVE_API_KEY === '') {
+        $output->error = "API key not configured.";
+        $output->json->vulgarity = null;
+    } else {
+        // Proceed if key is 'TEST_API_KEY' for testing the call structure,
+        // knowing it will likely fail with the actual API but allows testing the path.
+        $apiResponse = callPerspectiveAPI($premise, PERSPECTIVE_API_KEY);
+
+        if ($apiResponse === false) {
+            $output->error = "Error calling moderation API.";
+            $output->json->vulgarity = null;
+        } elseif (isset($apiResponse->attributeScores->OBSCENE->summaryScore->value)) {
+            $output->error = "";
+            $obsceneScore = $apiResponse->attributeScores->OBSCENE->summaryScore->value;
+            $output->json->vulgarity = $obsceneScore > OBSCENE_THRESHOLD;
+            // You could also store the score if needed:
+            // $output->json->scores = $apiResponse->attributeScores;
+        } else {
+            // Log the actual response for debugging if possible
+            // error_log("Invalid response from moderation API: " . json_encode($apiResponse));
+            $output->error = "Invalid response from moderation API.";
+            $output->json->vulgarity = null;
+            if (isset($apiResponse->error->message)) {
+                 $output->error .= " - API Message: " . $apiResponse->error->message;
+            }
+        }
+    }
+} else {
+    $apiResponse = callPerspectiveAPI($premise, PERSPECTIVE_API_KEY);
+
+    if ($apiResponse === false) {
+        $output->error = "Error calling moderation API.";
+        $output->json->vulgarity = null;
+    } elseif (isset($apiResponse->attributeScores->OBSCENE->summaryScore->value)) {
+        $output->error = ""; // Clear error if API call was successful and response is valid
+        $obsceneScore = $apiResponse->attributeScores->OBSCENE->summaryScore->value;
+        $output->json->vulgarity = $obsceneScore > OBSCENE_THRESHOLD;
+        // You could also store the full scores if needed for debugging or more complex logic:
+        // $output->json->scores = $apiResponse->attributeScores;
+    } else {
+        // Log the actual response for debugging if possible
+        // error_log("Invalid response from moderation API: " . json_encode($apiResponse));
+        $output->error = "Invalid response from moderation API.";
+        $output->json->vulgarity = null;
+         if (isset($apiResponse->error->message)) {
+             $output->error .= " - API Message: " . $apiResponse->error->message;
+         }
+    }
+}
+
+
+// Set the content type to application/json
+header('Content-Type: application/json');
+
+// Output the JSON response
+echo json_encode($output);
+
+?>

--- a/api/controllers/checkpremise.php
+++ b/api/controllers/checkpremise.php
@@ -77,6 +77,9 @@ function callPerspectiveAPI($text, $apiKey) {
 $premise = isset($_POST['premise']) ? $_POST['premise'] : '';
 $output->json = new stdClass();
 
+// Be lenient and allow the premise to be used if the API call fails.
+$output->json->reject = false;
+
 if (empty($premise)) {
     $output->error = "Premise input is empty.";
 } else {
@@ -97,8 +100,6 @@ if (empty($premise)) {
         } else {
             $output->json->error = "Error calling moderation API.";
         }
-        // Be lenient and allow the premise to be used if the API call fails.
-        $output->json->reject = false;
     }
 }
 ?>

--- a/api/index.php
+++ b/api/index.php
@@ -107,6 +107,9 @@
 		case 'log':
 			require __DIR__ . '/controllers/log.php';
 			break;
+		case 'checkpremise':
+			require __DIR__ . '/controllers/checkpremise.php';
+			break;
 		default:
 			$output->error = "Action not avaialble.";
 			break;

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -202,6 +202,13 @@ async function GenerateStrip() {
 	const imageModel = document.getElementById("image-model").value;
 	const imageStyle = document.getElementById("image-style").value;
 
+	let vulgarityCheck = await api.CheckVulgarity(safeQuery);
+	console.log("🚀 ~ GenerateStrip ~ vulgarityCheck:", vulgarityCheck);
+	//if(vulgarityCheck && vulgarityCheck.error) {
+		SetStatus("error");
+		return;
+	//}
+
 	let concept = await api.WriteConcept(safeQuery, { model: conceptModel });
 	if (!concept || concept.error) {
 		SetStatus(concept.error == "ratelimit" ? concept.error : "error");

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -203,11 +203,10 @@ async function GenerateStrip() {
 	const imageStyle = document.getElementById("image-style").value;
 
 	let vulgarityCheck = await api.CheckVulgarity(safeQuery);
-	console.log("🚀 ~ GenerateStrip ~ vulgarityCheck:", vulgarityCheck);
-	//if(vulgarityCheck && vulgarityCheck.error) {
-		SetStatus("error");
+	if(vulgarityCheck && vulgarityCheck.reject) {
+		SetStatus("profanity");
 		return;
-	//}
+	}
 
 	let concept = await api.WriteConcept(safeQuery, { model: conceptModel });
 	if (!concept || concept.error) {
@@ -310,6 +309,8 @@ function SetStatus(status) {
 		);
 	} else if (status === "ratelimit") {
 		alert("The daily limit for generating comics has been reached. Please try again tomorrow.");
+	} else if (status === "profanity") {
+		alert("The premise contains profanity. Please try again with a different premise.");
 	}
 
 	document.body.dataset.status = status;

--- a/scripts/modules/ComicGeneratorApi.js
+++ b/scripts/modules/ComicGeneratorApi.js
@@ -45,6 +45,13 @@ export class ComicGeneratorApi {
 		return result ? result.json : {};
 	}
 
+	async CheckVulgarity(premise) {
+		const result = await this.fetchApi("checkpremise", {
+			premise,
+		});
+		return result ? result.vulgarity : {};
+	}
+
 	async WriteConcept(premise, params) {
 		const { model } = params || {};
 		let result = await this.fetchApi("concept", {

--- a/scripts/modules/ComicGeneratorApi.js
+++ b/scripts/modules/ComicGeneratorApi.js
@@ -49,7 +49,7 @@ export class ComicGeneratorApi {
 		const result = await this.fetchApi("checkpremise", {
 			premise,
 		});
-		return result ? result.vulgarity : {};
+		return result ? result.json : {};
 	}
 
 	async WriteConcept(premise, params) {
@@ -430,7 +430,7 @@ export class ComicGeneratorApi {
 					body: formData,
 				});
 				const data = await response.json();
-				if (!data || (!data.json && !data.response) || data.error) {
+				if (!data || (!data.json && !data.response) || data.error || typeof data?.json?.reject !== "undefined") {
 					throw data;
 				} else {
 					console.log("ComicGenerator: API response", data);


### PR DESCRIPTION
## New Endpoint: Premise Vulgarity Check (`/api/checkpremise`)

**Branch:** `feat/premise-vulgarity-check`

This Pull Request introduces a new API endpoint, `/api/checkpremise`, designed to assess a given text "premise" for obscene content using Google's Perspective API.

### Features & Implementation Details:

1.  **New Controller**: `api/controllers/checkpremise.php`
    *   Accepts a POST request with a single string parameter: `premise`.
    *   The premise can be in any language (as supported by the Perspective API).

2.  **Content Moderation**:
    *   Utilizes the Perspective API (via `commentanalyzer.googleapis.com`) to analyze the premise.
    *   Specifically requests scores for "OBSCENE", "TOXICITY", and "SEVERE_TOXICITY" attributes.
    *   Uses the `GOOGLE_KEY` constant (expected to be defined in `api/includes/key.php`) for API authentication.

3.  **JSON Output Structure**:
    *   The endpoint returns the standard JSON output object used by other API endpoints.
    *   A new top-level property `$output->vulgarity` is added.
        *   On successful analysis, `$output->vulgarity` is an object containing:
            *   `score`: The raw numerical score for the "OBSCENE" attribute.
            *   `reject`: A boolean, `true` if the OBSCENE score exceeds a defined threshold (currently 0.5), `false` otherwise.
        *   In case of any error (e.g., empty premise, API key issue, API call failure), `$output->vulgarity` is set to `null`.
    *   `$output->error` is populated with relevant error messages if issues occur.
    *   The controller does not set `$output->model`.

4.  **Routing**:
    *   `api/index.php` has been updated to route requests for `/api/checkpremise` to the new controller.

5.  **Error Handling & Configuration**:
    *   Handles cases like empty premise input.
    *   Relies on `api/index.php` for global setup, including the definition of `GOOGLE_KEY` and initialization of the base `$output` object.
    *   If `GOOGLE_KEY` is not defined or is empty, an appropriate error is returned, and vulgarity analysis is not performed.
    *   Includes a fallback `TEST_GOOGLE_KEY_ISOLATED` definition within the controller for isolated testing scenarios, clearly indicating if this test key is used in error messages.

### Testing:

*   The controller has undergone iterative development with multiple rounds of testing using PHP CLI and wrapper scripts.
*   Tests included:
    *   PHP lint checks.
    *   Handling of empty/missing premise input.
    *   Behavior with a defined (but test/invalid) API key, verifying error reporting and output structure.
    *   Behavior with a simulated unconfigured/empty API key.
*   The endpoint successfully returns the specified JSON structure, including the `vulgarity` object (or null) and error messages.

### How to Use:

Send a POST request to `/api/checkpremise` with the following data:
`premise=Your text premise here`

This endpoint provides a way to moderate user-supplied text before further processing or generation tasks.